### PR TITLE
Fix website crash issue

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,31 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Zola
+        uses: taiki-e/install-action@v2
+        with:
+          tool: zola@0.19.2
+
+      - name: Build with Zola
+        run: zola build
+
+      - name: Check build output
+        run: |
+          if [ ! -d "public" ]; then
+            echo "Build failed: public directory not created"
+            exit 1
+          fi
+          echo "Build successful!"

--- a/config.toml
+++ b/config.toml
@@ -17,9 +17,10 @@ highlight_theme = "css"
 author = "Josh Moles"
 email = "contact@joshmoles.com"
 
-# Navigation links
-nav = [
-    { name = "About", url = "/about" },
+# Header navigation (required by anemone theme)
+header_nav = [
+    { url = "/", name_en = "/home/" },
+    { url = "/about", name_en = "/about/" },
 ]
 
 # Social links for anemone theme

--- a/content/about.md
+++ b/content/about.md
@@ -3,15 +3,11 @@ title = "About"
 template = "page.html"
 +++
 
-This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](https://jekyllrb.com/)
+# About Josh Moles
 
-You can find the source code for Minima at GitHub:
-[jekyll](https://github.com/jekyll) /
-[minima](https://github.com/jekyll/minima)
+Software engineer and technology enthusiast.
 
-You can find the source code for Jekyll at GitHub:
-[jekyll](https://github.com/jekyll) /
-[jekyll](https://github.com/jekyll/jekyll)
-
-
-[jekyll-organization]: https://github.com/jekyll
+You can find me on:
+- [Bluesky](https://bsky.app/profile/joshmoles.com)
+- [GitHub](https://github.com/jmoles)
+- [LinkedIn](https://www.linkedin.com/in/josh-moles/)

--- a/content/about.md
+++ b/content/about.md
@@ -5,7 +5,7 @@ template = "page.html"
 
 # About Josh Moles
 
-Software engineer and technology enthusiast.
+Computer engineer and technology enthusiast.
 
 You can find me on:
 - [Bluesky](https://bsky.app/profile/joshmoles.com)


### PR DESCRIPTION
This commit addresses the site build failures:
- Initialize anemone theme git submodule (was empty causing build to fail)
- Update about.md to remove outdated Jekyll references
- Add GitHub Actions workflow to validate PRs before merging